### PR TITLE
Flush cache during prefetch

### DIFF
--- a/lib/puppet/provider/neutron_network/neutron.rb
+++ b/lib/puppet/provider/neutron_network/neutron.rb
@@ -25,6 +25,10 @@ Puppet::Type.type(:neutron_network).provide(
     end
   end
 
+  def self.prefetch
+    @existing_resources = nil
+  end
+
   def self.existing_resources_as_hash()
     @existing_resources ||= begin
       resources_hash = {}


### PR DESCRIPTION
to ensure it is rebuilt every run
of Puppet.